### PR TITLE
Update title to Senior Software Engineering Manager

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: Zack Koppert # your name (or website title) here
 logo: "/images/logo.jpg?raw=true" # your photo (or logo) here
 description: > # your text below (remove <br> elements if you don't need line breaks)
-  Senior Software Engineer @ GitHub, OSPO
+  Senior Software Engineering Manager @ GitHub
   <br>
   Previously @ Tektronix, Open Source Team
   <br><br>


### PR DESCRIPTION
Updates the side panel title from "Senior Software Engineer @ GitHub, OSPO" to "Senior Software Engineering Manager @ GitHub".